### PR TITLE
Remove dependecy on import datastore config.

### DIFF
--- a/src/gobbagextract/prepare/prepare_client.py
+++ b/src/gobbagextract/prepare/prepare_client.py
@@ -2,8 +2,9 @@ from datetime import datetime
 
 from gobcore.enum import ImportMode
 from gobcore.logging.logger import logger
-from gobconfig.datastore.config import get_datastore_config
+from gobconfig.datastore.config import TYPE_POSTGRES
 
+from gobbagextract.config import DATABASE_CONFIG
 from gobbagextract.datastore.postgres import PostgresDatastoreExt
 from gobbagextract.selector.datastore_to_postgres import DatastoreToPostgresSelector
 from gobbagextract.datastore.bag_extract import BagExtractDatastore
@@ -25,7 +26,8 @@ class PrepareClient:
         read_config = dataset.get('source', {}).get('read_config', {})
         read_config['mode'] = mode
         self._data_src = BagExtractDatastore(dict(), read_config, last_date)
-        data_store_config = get_datastore_config('BAGExtract')
+        data_store_config = DATABASE_CONFIG | {'type': TYPE_POSTGRES}
+        data_store_config.pop('drivername')
         self._data_dst = PostgresDatastoreExt(data_store_config)
         self.source_app = self.dataset.get('source', {}).get('application')
         self._config = {

--- a/src/tests/prepare/test_prepare_client.py
+++ b/src/tests/prepare/test_prepare_client.py
@@ -3,15 +3,17 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 
 from gobcore.enum import ImportMode
+from gobconfig.datastore.config import TYPE_POSTGRES
+
+from gobbagextract.config import DATABASE_CONFIG
 from gobbagextract.prepare.prepare_client import PrepareClient
 
 
 class TestPrepareClient(TestCase):
 
     @patch('gobbagextract.prepare.prepare_client.PostgresDatastoreExt')
-    @patch('gobbagextract.prepare.prepare_client.get_datastore_config')
     @patch('gobbagextract.prepare.prepare_client.BagExtractDatastore')
-    def test_init(self, mock_BagExtractDatastore, mock_get_datastore_config, mock_postgres_ds):
+    def test_init(self, mock_BagExtractDatastore, mock_postgres_ds):
         dataset = {
             'catalogue': 'bag',
             'entity': 'ENT',
@@ -29,11 +31,11 @@ class TestPrepareClient(TestCase):
         mode = ImportMode.FULL
         last_date = datetime.datetime.now().date()
         read_config = dataset['source']['read_config']
-        ds_config = 'DS_CONFIG'
-        mock_get_datastore_config.return_value = ds_config
         PrepareClient(msg, dataset, mode, last_date)
         mock_BagExtractDatastore.assert_called_with({}, read_config, last_date)
         mock_postgres_ds.assert_called_once()
+        ds_config = DATABASE_CONFIG | {'type': TYPE_POSTGRES}
+        ds_config.pop('drivername')
         mock_postgres_ds.assert_called_with(ds_config)
 
     def test_connect(self):


### PR DESCRIPTION
Do not use the import datastore config to get
the bagextract datastore connection.