### PR TITLE
Give warning, no error, will be retried.

### DIFF
--- a/src/gobbagextract/__main__.py
+++ b/src/gobbagextract/__main__.py
@@ -72,7 +72,7 @@ def handle_bag_extract_message(msg: dict) -> dict:
     while next_mutation:
         msg, next_mutation = _handle_mutation_import(msg, dataset, mutations_handler)
         if next_mutation:
-            logger.info('Next mutaion is available, keep processing')
+            logger.info('Next mutation is available, keep processing')
     logger.info("This was the last file to be exctracted for now.")
     return msg
 

--- a/src/gobbagextract/__main__.py
+++ b/src/gobbagextract/__main__.py
@@ -35,7 +35,7 @@ def _handle_mutation_import(msg: dict, dataset: dict, mutations_handler: Mutatio
         try:
             mutation_import, updated_dataset, mutation_date = mutations_handler.get_next_import(last_import)
         except NothingToDo as e:
-            logger.warning(f"Nothing to do: {e}")
+            logger.info(f"Nothing to do: {e}")
             msg['summary'] = logger.get_summary()
             return msg, False
 

--- a/src/gobbagextract/__main__.py
+++ b/src/gobbagextract/__main__.py
@@ -35,7 +35,7 @@ def _handle_mutation_import(msg: dict, dataset: dict, mutations_handler: Mutatio
         try:
             mutation_import, updated_dataset, mutation_date = mutations_handler.get_next_import(last_import)
         except NothingToDo as e:
-            logger.error(f"Nothing to do: {e}")
+            logger.warning(f"Nothing to do: {e}")
             msg['summary'] = logger.get_summary()
             return msg, False
 
@@ -45,7 +45,7 @@ def _handle_mutation_import(msg: dict, dataset: dict, mutations_handler: Mutatio
         dataset = updated_dataset
         mode = ImportMode(mutation_import.mode)
 
-        prepare_client = PrepareClient(msg, dataset, mode, mutation_date)
+        msg = prepare_client = PrepareClient(msg, dataset, mode, mutation_date)
 
         prepare_client.import_dataset()
         mutation_import.ended_at = datetime.datetime.utcnow()
@@ -70,7 +70,7 @@ def handle_bag_extract_message(msg: dict) -> dict:
     mutations_handler = MutationsHandler(dataset)
     next_mutation = True
     while next_mutation:
-        nsg, next_mutation = _handle_mutation_import(msg, dataset, mutations_handler)
+        msg, next_mutation = _handle_mutation_import(msg, dataset, mutations_handler)
         if next_mutation:
             logger.info('Next mutaion is available, keep processing')
     logger.info("This was the last file to be exctracted for now.")

--- a/src/gobbagextract/config.py
+++ b/src/gobbagextract/config.py
@@ -11,3 +11,7 @@ DATABASE_CONFIG = {
 }
 
 BAGEXTRACT_DOWNLOAD_URL = os.getenv("BAGEXTRACT_DOWNLOAD_URL", "https://extracten.bag.kadaster.nl/lvbag/extracten")
+
+# When no BAG mutations (or full) are available, when to give a warning
+BAGEXTRACT_NOT_AVAIL_DAYS_WARNING = os.getenv("BAGEXTRACT_NOT_AVAIL_DAYS_WARNING", 2)
+BAGEXTRACT_NOT_AVAIL_DAYS_ERROR = os.getenv("BAGEXTRACT_NOT_AVAIL_DAYS_ERROR", 5)

--- a/src/gobbagextract/mutations/bagextract.py
+++ b/src/gobbagextract/mutations/bagextract.py
@@ -3,6 +3,8 @@ import re
 from typing import Tuple
 
 import htmllistparse
+
+from dateutil.relativedelta import relativedelta
 from gobcore.exceptions import GOBException
 from gobcore.enum import ImportMode
 from gobbagextract.config import BAGEXTRACT_DOWNLOAD_URL
@@ -17,15 +19,8 @@ class BagExtractMutationsHandler:
     def _last_full_import_date(self):
         now = datetime.date.today()
         if now.day < self.FULL_IMPORT_DAY:
-            new_month = now.month - 1
-            new_year = now.year - 1 if new_month <= 0 else now.year
-            return now.replace(
-                month=new_month if new_month > 0 else new_month + 12,
-                year=new_year,
-                day=self.FULL_IMPORT_DAY
-            )
-        else:
-            return now.replace(day=self.FULL_IMPORT_DAY)
+            now -= relativedelta(months=1)
+        return now.replace(day=self.FULL_IMPORT_DAY)
 
     def _date_gemeente_from_filename(self, filename: str) -> datetime.date:
         m = re.match(r"^BAGGEM(\d{4})L-(\d{2})(\d{2})(\d{4}).zip$", filename)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -136,6 +136,7 @@ class TestMain(TestCase):
         mock_mutations_handler.get_next_import.side_effect = NothingToDo()
         dataset = {'header': 'bello'}
         ret = _handle_mutation_import(self.mock_msg, dataset, mock_mutations_handler)
+        mock_logger.warning.assert_called_once()
         self.assertEqual(ret[1], False)
 
     @patch("gobbagextract.__main__.get_extract_definition")

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -136,7 +136,7 @@ class TestMain(TestCase):
         mock_mutations_handler.get_next_import.side_effect = NothingToDo()
         dataset = {'header': 'bello'}
         ret = _handle_mutation_import(self.mock_msg, dataset, mock_mutations_handler)
-        mock_logger.warning.assert_called_once()
+        self.assertEqual(mock_logger.info.call_count, 2)
         self.assertEqual(ret[1], False)
 
     @patch("gobbagextract.__main__.get_extract_definition")


### PR DESCRIPTION
Giving errors in log, will retry job, resulting in 2 errors.
Warning is sufficient here. When jobs are done every day, mutations files should be ready for the previous day.