### PR TITLE
Return as all other message handlers.

### DIFF
--- a/src/gobbagextract/__main__.py
+++ b/src/gobbagextract/__main__.py
@@ -50,7 +50,10 @@ def _handle_mutation_import(msg: dict, dataset: dict, mutations_handler: Mutatio
         except NothingToDo as e:
             logger.info(f"Nothing to do: {e}")
             _log_no_more_left(last_import)
-            msg['summary'] = logger.get_summary()
+            msg = {
+                'header': msg.get('header', {}),
+                'summary': logger.get_summary(),
+            }
             return msg, False
 
         repo.save(mutation_import)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.14g#egg=gobconfig
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.11t#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.11x#egg=gobcore
 alembic==1.5.5
 htmllistparse==0.6.0
 # No need to spec versions for packages only used during testing

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.4.14g#egg=gobconfig
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.11j#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.11t#egg=gobcore
 alembic==1.5.5
 htmllistparse==0.6.0
 # No need to spec versions for packages only used during testing

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -139,9 +139,11 @@ class TestMain(TestCase):
         mock_mutations_handler = Mock()
         mock_mutations_handler.get_next_import.side_effect = NothingToDo()
         dataset = {'header': 'bello'}
-        ret = _handle_mutation_import(self.mock_msg, dataset, mock_mutations_handler)
+        msg, last = _handle_mutation_import(self.mock_msg, dataset, mock_mutations_handler)
+        summary = mock_logger.get_summary()
         self.assertEqual(mock_logger.info.call_count, 2)
-        self.assertEqual(ret[1], False)
+        self.assertEqual(last, False)
+        self.assertEqual(msg, {'header': self.mock_msg['header'], 'summary': summary})
         _log_no_more_left.assert_called_once()
 
     @patch("gobbagextract.__main__.get_extract_definition")


### PR DESCRIPTION
Bagextract workflow jobs wer not stopped and
therefore had a wrench in the status.