### PR TITLE
Remove `logging.configure` calls (#40)

### DIFF
--- a/src/gobbagextract/__main__.py
+++ b/src/gobbagextract/__main__.py
@@ -16,6 +16,7 @@ from gobcore.exceptions import GOBException
 from gobcore.logging.logger import logger
 from gobcore.message_broker.config import WORKFLOW_EXCHANGE, BAG_EXTRACT_QUEUE, BAG_EXTRACT_RESULT_KEY
 from gobcore.message_broker.messagedriven_service import messagedriven_service
+from gobcore.message_broker.typing import ServiceDefinition
 
 
 def _log_no_more_left(last_import: MutationImport):
@@ -100,7 +101,6 @@ def handle_bag_extract_message(msg: dict) -> dict:
         "catalogue": dataset["catalogue"],
         "entity": dataset["entity"],
     }
-    logger.configure(msg, "BAG EXTRACT")
     mutations_handler = MutationsHandler(dataset)
     next_mutation = True
     while next_mutation:
@@ -140,15 +140,15 @@ def _validate_message(msg: Dict[str, Any]) -> None:
         )
 
 
-SERVICEDEFINITION = {
+SERVICEDEFINITION: ServiceDefinition = {
     "bag_extract_request": {
         "queue": BAG_EXTRACT_QUEUE,
         "handler": handle_bag_extract_message,
         "report": {
             "exchange": WORKFLOW_EXCHANGE,
             "key": BAG_EXTRACT_RESULT_KEY,
-        },
-    },
+        }
+    }
 }
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
--e git+https://github.com/Amsterdam/GOB-Config.git@v0.6.0#egg=gobconfig
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.17.21#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Config.git@v0.7.0#egg=gobconfig
+-e git+https://github.com/Amsterdam/GOB-Core.git@v1.9.0#egg=gobcore
 alembic==1.8.1
 # No need to spec versions for packages only used during testing
 freezegun~=1.2.2

--- a/src/tests/test_handle_bag_extract.py
+++ b/src/tests/test_handle_bag_extract.py
@@ -21,7 +21,11 @@ class TestHandleBagExtract:
         GOB logger cannot be overwritten with logging.setLoggerClass as it is not compatible with that.
         :return: A generator which yields the mocked logger.
         """
-        with mock.patch("gobbagextract.__main__.logger") as p:
+        with (
+            mock.patch("gobbagextract.__main__.logger") as p,
+            mock.patch("gobbagextract.selector._selector.logger"),
+            mock.patch("gobbagextract.prepare.prepare_client.logger")
+        ):
             yield p
 
     @pytest.fixture


### PR DESCRIPTION
* Remove `logging.configure` calls

update core

* Mock extra loggers